### PR TITLE
Update nodes.py

### DIFF
--- a/pywr/nodes.py
+++ b/pywr/nodes.py
@@ -373,7 +373,7 @@ class Storage(Loadable, Drawable, Connectable, _core.Storage, metaclass=NodeMeta
             self.model.graph.add_node(node)
 
     def iter_slots(self, slot_name=None, is_connector=True, all_slots=False):
-        if is_connector:
+        if not is_connector:
             if not self.inputs:
                 raise StopIteration
             if slot_name is None:


### PR DESCRIPTION
Altering storage.iter_tools method with "not" to behaviour when connecting to and from storage slots. Previously, connecting from a storage to another node would access the "to_slots" instead of the "from_slots", and vice versa when connecting nodes to storage slots. The edit tries to invert this behaviour.